### PR TITLE
Add caching to disk

### DIFF
--- a/src/IssueCreator/Dialogs/RepoSelector.cs
+++ b/src/IssueCreator/Dialogs/RepoSelector.cs
@@ -1,4 +1,5 @@
-﻿using Octokit;
+﻿using IssueCreator.Models;
+using Octokit;
 using System;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -48,7 +49,7 @@ namespace IssueCreator
         {
             try
             {
-                Repository repo = await _issueManager.GetRepositoryAsync(organization, repository);
+                RepositoryInfo repo = await _issueManager.GetRepositoryAsync(organization, repository);
                 return true;
             }
             catch

--- a/src/IssueCreator/IssueCreator.csproj
+++ b/src/IssueCreator/IssueCreator.csproj
@@ -186,6 +186,8 @@
     <Compile Include="Dialogs\TextInput.Designer.cs">
       <DependentUpon>TextInput.cs</DependentUpon>
     </Compile>
+    <Compile Include="Models\Contributor.cs" />
+    <Compile Include="Models\IssueObject.cs" />
     <Compile Include="Models\IssueToCreate.cs" />
     <Compile Include="Models\IssueDescription.cs" />
     <Compile Include="IssueManager.cs" />
@@ -196,6 +198,8 @@
       <DependentUpon>Main.cs</DependentUpon>
     </Compile>
     <Compile Include="Models\IssueMilestone.cs" />
+    <Compile Include="Models\RepoLabel.cs" />
+    <Compile Include="Models\RepositoryInfo.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />

--- a/src/IssueCreator/IssueManager.cs
+++ b/src/IssueCreator/IssueManager.cs
@@ -1,12 +1,15 @@
 ﻿using Azure;
 using IssueCreator.Models;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Octokit;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using ZenHub;
 using ZenHub.Models;
@@ -15,9 +18,10 @@ namespace IssueCreator
 {
     public class IssueManager
     {
-        ZenHubClient _zenHubClient;
-        GitHubClient _githubClient;
-        MemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+        private ZenHubClient _zenHubClient;
+        private GitHubClient _githubClient;
+        private MemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+        private Dictionary<string, Type> _cacheEntries = new Dictionary<string, Type>(); //keeps track of the keys added to the cache
 
         public static IssueManager Create(Settings settings)
         {
@@ -61,23 +65,23 @@ namespace IssueCreator
             }
         }
 
-        public async Task<IReadOnlyList<Milestone>> GetMilestonesAsync(string owner, string repo)
+        public async Task<List<IssueMilestone>> GetMilestonesAsync(string owner, string repo)
         {
-            IReadOnlyList<Milestone> milestones = await GetValueFromCache(StringTemplate.Milestones(owner, repo), () => _githubClient.Issue.Milestone.GetAllForRepository(owner, repo));
+            List<IssueMilestone> milestones = await GetValueFromCache(StringTemplate.Milestones(owner, repo), async () => IssueMilestone.FromMilestoneList(await _githubClient.Issue.Milestone.GetAllForRepository(owner, repo)));
 
             return milestones;
         }
 
-        public async Task<IReadOnlyList<Label>> GetLabelsAsync(string owner, string repo)
+        public async Task<List<RepoLabel>> GetLabelsAsync(string owner, string repo)
         {
-            IReadOnlyList<Label> labels = await GetValueFromCache(StringTemplate.Labels(owner, repo), () => _githubClient.Issue.Labels.GetAllForRepository(owner, repo));
+            List<RepoLabel> labels = await GetValueFromCache(StringTemplate.Labels(owner, repo), async () => RepoLabel.FromLabelList(await _githubClient.Issue.Labels.GetAllForRepository(owner, repo)));
 
             return labels;
         }
 
-        public async Task<IReadOnlyList<RepositoryContributor>> GetContributorsAsync(string owner, string repo)
+        public async Task<List<GitHubContributor>> GetContributorsAsync(string owner, string repo)
         {
-            IReadOnlyList<RepositoryContributor> contributors = await GetValueFromCache(StringTemplate.Contributors(owner,repo), () => _githubClient.Repository.GetAllContributors(owner, repo));
+            List<GitHubContributor> contributors = await GetValueFromCache(StringTemplate.Contributors(owner, repo), async () => GitHubContributor.FromContributorsList( await _githubClient.Repository.GetAllContributors(owner, repo)));
             return contributors;
         }
 
@@ -129,9 +133,9 @@ namespace IssueCreator
             return await _githubClient.Issue.Create(owner, repo, issue);
         }
 
-        public async Task<Repository> GetRepositoryAsync(string owner, string repo)
+        public async Task<RepositoryInfo> GetRepositoryAsync(string owner, string repo)
         {
-            return await GetValueFromCache(StringTemplate.Repo(owner,repo), () => _githubClient.Repository.Get(owner, repo));
+            return await GetValueFromCache(StringTemplate.Repo(owner, repo), async () => new RepositoryInfo(await _githubClient.Repository.Get(owner, repo)));
         }
 
         internal async Task<(bool, string)> TryCreateNewIssueAsync(IssueToCreate issueToCreate)
@@ -172,7 +176,7 @@ namespace IssueCreator
 
             try
             {
-                Repository repoFromGH = await GetRepositoryAsync(issueToCreate.Organization, issueToCreate.Repository);
+                RepositoryInfo repoFromGH = await GetRepositoryAsync(issueToCreate.Organization, issueToCreate.Repository);
                 // assign the epic, if one is selected
                 if (issueToCreate.Epic != null)
                 {
@@ -201,9 +205,9 @@ namespace IssueCreator
             return (true, string.Empty);
         }
 
-        public async Task<Issue> GetIssueAsync(long repoId, int issueNumber)
+        public async Task<IssueObject> GetIssueAsync(long repoId, int issueNumber)
         {
-            Issue issue = await GetValueFromCache(StringTemplate.Issue(repoId, issueNumber), () => _githubClient.Issue.Get(repoId, issueNumber));
+            IssueObject issue = await GetValueFromCache(StringTemplate.Issue(repoId, issueNumber), async () => new IssueObject(await _githubClient.Issue.Get(repoId, issueNumber)));
             return issue;
         }
 
@@ -225,16 +229,16 @@ namespace IssueCreator
 
                 tasks[count++] = Task.Run(async () =>
                 {
-                    Repository gitHubRepoObj = await GetRepositoryAsync(owner, repo);
+                    RepositoryInfo gitHubRepoObj = await GetRepositoryAsync(owner, repo);
 
-                    Response<EpicList> epicList = await GetValueFromCache(StringTemplate.Epic(owner, repo), () => _zenHubClient.GetRepositoryClient(gitHubRepoObj.Id).GetEpicsAsync(), DateTimeOffset.Now.AddHours(1));
+                    EpicList epicList = await GetValueFromCache(StringTemplate.Epic(owner, repo), async () => (await _zenHubClient.GetRepositoryClient(gitHubRepoObj.Id).GetEpicsAsync()).Value, DateTimeOffset.Now.AddHours(1));
 
-                    foreach (EpicInfo epic in epicList.Value.Epics)
+                    foreach (EpicInfo epic in epicList.Epics)
                     {
                         long repoId = epic.RepositoryId;
                         int issueNumber = epic.IssueNumber;
                         // from the issue link, get the cached issue from the repo
-                        Issue issue = await GetIssueAsync(repoId, issueNumber);
+                        IssueObject issue = await GetIssueAsync(repoId, issueNumber);
 
                         result.Add(new IssueDescription() { Issue = issue, Repo = gitHubRepoObj });
                     }
@@ -252,6 +256,9 @@ namespace IssueCreator
             return (parts[0], parts[1]);
         }
 
+        /// <summary>
+        /// This is the code that calls into the cache.
+        /// </summary>
         private async Task<TResult> GetValueFromCache<TResult>(string key, Func<Task<TResult>> getValue, DateTimeOffset cacheDuration = default)
         {
             TResult itemInCache = _cache.Get<TResult>(key);
@@ -260,8 +267,10 @@ namespace IssueCreator
                 return itemInCache;
             }
 
-            // add the value to the cache.
+            // add the current key to the list of entries in the cache
+            _cacheEntries[key]=  typeof(TResult);
 
+            // add the value to the cache.
             if (cacheDuration == default)
             {
                 cacheDuration = DateTimeOffset.Now.AddHours(8);
@@ -273,18 +282,73 @@ namespace IssueCreator
             return valueToCache;
         }
 
+        public void SerializeCacheDataToFolder(string folder)
+        {
+            foreach (KeyValuePair<string, Type> item in _cacheEntries)
+            {
+                object obj = _cache.Get(item.Key);
+                if (obj == null)
+                {
+                    continue;
+                }
+
+                // serialize it to disk.
+                using (StreamWriter sw = new StreamWriter($"{Path.Combine(folder, item.Key)}.json"))
+                {
+                    sw.Write(JsonSerializer.Serialize(obj, item.Value));
+                }
+            }
+        }
+
+        public bool DeserializeCacheDataFromFolder(string folder)
+        {
+            bool deserializedData = false;
+            foreach (string file in Directory.GetFiles(folder, "*.json"))
+            {
+                // serialize it to disk.
+                using (StreamReader sr = new StreamReader(file))
+                {
+                    string key = Path.GetFileNameWithoutExtension(file);
+                    Type cacheType = StringTemplate.GetType(key);
+
+                    object deserializedObject = JsonSerializer.Deserialize(sr.ReadToEnd(), cacheType);
+
+                    _cache.Set(key, deserializedObject, DateTimeOffset.Now.AddMinutes(10));
+                    deserializedData = true;
+                }
+            }
+
+            return deserializedData;
+        }
+
+
         internal void RemoveRepoFromCache(string owner, string repo)
         {
             _cache.Remove(StringTemplate.Repo(owner, repo));
+            _cacheEntries.Remove(StringTemplate.Repo(owner, repo));
         }
 
         internal void RemoveEpicFromCache(string owner, string repo)
         {
             _cache.Remove(StringTemplate.Epic(owner, repo));
+            _cacheEntries.Remove(StringTemplate.Epic(owner, repo));
         }
 
         internal static class StringTemplate
         {
+            public static Type GetType(string template)
+            {
+                // figure out the type we need.
+                if (template.ToLowerInvariant().StartsWith("epic")) return typeof(EpicList);
+                else if (template.ToLowerInvariant().StartsWith("issue")) return typeof(IssueObject);
+                else if (template.ToLowerInvariant().StartsWith("repo")) return typeof(RepositoryInfo);
+                else if (template.ToLowerInvariant().StartsWith("milestones")) return typeof(List<IssueMilestone>);
+                else if (template.ToLowerInvariant().StartsWith("labels")) return typeof(List<RepoLabel>);
+                else if (template.ToLowerInvariant().StartsWith("contributors")) return typeof(List<GitHubContributor>);
+                return null;
+            }
+
+
             public static string Epic(string owner, string repo) => $"epic_{owner}_{repo}";
             public static string Repo(string owner, string repo) => $"repo_{owner}_{repo}";
             public static string Milestones(string owner, string repo) => $"milestones_{owner}_{repo}";
@@ -294,3 +358,4 @@ namespace IssueCreator
         }
     }
 }
+

--- a/src/IssueCreator/Main.cs
+++ b/src/IssueCreator/Main.cs
@@ -19,9 +19,25 @@ namespace IssueCreator
         private static IssueManager s_issueManager;
         private static IssueToCreate s_previouslyCreatedIssue;
 
-        private static string SettingsFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "IssueCreator");
-        private static string CacheFolder = Path.Combine(SettingsFolder, "Cache");
-        private static string SettingsFile = Path.Combine(SettingsFolder, "issueCreator.settings");
+        private static readonly string SettingsFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "IssueCreator");
+        private static readonly string SettingsFile = Path.Combine(SettingsFolder, "issueCreator.settings");
+        private static string CacheFolder
+        {
+            get
+            {
+                // if this is deployed via Click-once, use the data folder
+                if (ApplicationDeployment.IsNetworkDeployed)
+                {
+                    return Path.Combine(ApplicationDeployment.CurrentDeployment.DataDirectory, "Cache");
+                }
+                else
+                {
+                    // otherwise, use a different folder.
+                    return Path.Combine(SettingsFolder, "Cache");
+                }
+            }
+        }
+
 
         public frmMain()
         {

--- a/src/IssueCreator/Main.cs
+++ b/src/IssueCreator/Main.cs
@@ -203,7 +203,7 @@ namespace IssueCreator
         {
             (string owner, string repository) = GetRepoOwner();
 
-            List<IssueMilestone> milestones = await s_issueManager.GetMilestonesAsync(owner, repository);
+            IEnumerable<IssueMilestone> milestones = await s_issueManager.GetMilestonesAsync(owner, repository);
 
             cboMilestones.Enabled = false;
 

--- a/src/IssueCreator/Main.designer.cs
+++ b/src/IssueCreator/Main.designer.cs
@@ -33,16 +33,13 @@ namespace IssueCreator
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmMain));
             this.label1 = new System.Windows.Forms.Label();
-            this.txtIssueTitle = new IssueCreator.Controls.TextBoxEx();
             this.label2 = new System.Windows.Forms.Label();
             this.cboAvailableRepos = new System.Windows.Forms.ComboBox();
             this.label3 = new System.Windows.Forms.Label();
-            this.txtDescription = new IssueCreator.Controls.TextBoxEx();
             this.btnAddTag = new System.Windows.Forms.Button();
             this.label4 = new System.Windows.Forms.Label();
             this.btnRemoveTag = new System.Windows.Forms.Button();
             this.label5 = new System.Windows.Forms.Label();
-            this.cboAssignees = new IssueCreator.Controls.ComboBoxWithSearch();
             this.btnCreateIssue = new System.Windows.Forms.Button();
             this.label6 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
@@ -54,14 +51,19 @@ namespace IssueCreator
             this.preferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.lblEpic = new System.Windows.Forms.Label();
             this.btnRefreshEpics = new System.Windows.Forms.Button();
-            this.txtEstimate = new IssueCreator.Controls.TextBoxEx();
             this.label8 = new System.Windows.Forms.Label();
-            this.cboEpics = new IssueCreator.Controls.ComboBoxWithSearch();
-            this.lstAvailableTags = new IssueCreator.Controls.ListBoxWithSearch();
-            this.lstSelectedTags = new IssueCreator.Controls.ListBoxWithSearch();
             this.chkMakeEpic = new System.Windows.Forms.CheckBox();
             this.label9 = new System.Windows.Forms.Label();
             this.cboMilestones = new IssueCreator.Controls.ComboBoxWithSearch();
+            this.txtEstimate = new IssueCreator.Controls.TextBoxEx();
+            this.cboEpics = new IssueCreator.Controls.ComboBoxWithSearch();
+            this.lstAvailableTags = new IssueCreator.Controls.ListBoxWithSearch();
+            this.cboAssignees = new IssueCreator.Controls.ComboBoxWithSearch();
+            this.lstSelectedTags = new IssueCreator.Controls.ListBoxWithSearch();
+            this.txtDescription = new IssueCreator.Controls.TextBoxEx();
+            this.txtIssueTitle = new IssueCreator.Controls.TextBoxEx();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -75,16 +77,6 @@ namespace IssueCreator
             this.label1.Size = new System.Drawing.Size(36, 18);
             this.label1.TabIndex = 0;
             this.label1.Text = "Title";
-            // 
-            // txtIssueTitle
-            // 
-            this.txtIssueTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtIssueTitle.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtIssueTitle.Location = new System.Drawing.Point(93, 108);
-            this.txtIssueTitle.Name = "txtIssueTitle";
-            this.txtIssueTitle.Size = new System.Drawing.Size(497, 26);
-            this.txtIssueTitle.TabIndex = 3;
             // 
             // label2
             // 
@@ -119,19 +111,6 @@ namespace IssueCreator
             this.label3.Size = new System.Drawing.Size(78, 18);
             this.label3.TabIndex = 4;
             this.label3.Text = "Description";
-            // 
-            // txtDescription
-            // 
-            this.txtDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtDescription.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.txtDescription.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtDescription.Location = new System.Drawing.Point(93, 140);
-            this.txtDescription.Multiline = true;
-            this.txtDescription.Name = "txtDescription";
-            this.txtDescription.Size = new System.Drawing.Size(497, 151);
-            this.txtDescription.TabIndex = 4;
             // 
             // btnAddTag
             // 
@@ -179,20 +158,6 @@ namespace IssueCreator
             this.label5.Size = new System.Drawing.Size(80, 18);
             this.label5.TabIndex = 12;
             this.label5.Text = "Assigned to";
-            // 
-            // cboAssignees
-            // 
-            this.cboAssignees.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.cboAssignees.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.cboAssignees.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.cboAssignees.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cboAssignees.FormattingEnabled = true;
-            this.cboAssignees.Location = new System.Drawing.Point(93, 76);
-            this.cboAssignees.Name = "cboAssignees";
-            this.cboAssignees.Size = new System.Drawing.Size(497, 26);
-            this.cboAssignees.Sorted = true;
-            this.cboAssignees.TabIndex = 2;
             // 
             // btnCreateIssue
             // 
@@ -253,6 +218,7 @@ namespace IssueCreator
             // menuStrip1
             // 
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.fileToolStripMenuItem,
             this.editToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
@@ -298,15 +264,6 @@ namespace IssueCreator
             this.btnRefreshEpics.UseVisualStyleBackColor = true;
             this.btnRefreshEpics.Click += new System.EventHandler(this.BtnRefreshEpics_Click);
             // 
-            // txtEstimate
-            // 
-            this.txtEstimate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.txtEstimate.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtEstimate.Location = new System.Drawing.Point(93, 472);
-            this.txtEstimate.Name = "txtEstimate";
-            this.txtEstimate.Size = new System.Drawing.Size(63, 26);
-            this.txtEstimate.TabIndex = 24;
-            // 
             // label8
             // 
             this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
@@ -318,51 +275,6 @@ namespace IssueCreator
             this.label8.Size = new System.Drawing.Size(61, 18);
             this.label8.TabIndex = 23;
             this.label8.Text = "Estimate";
-            // 
-            // cboEpics
-            // 
-            this.cboEpics.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.cboEpics.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.cboEpics.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.cboEpics.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cboEpics.FormattingEnabled = true;
-            this.cboEpics.IntegralHeight = false;
-            this.cboEpics.Location = new System.Drawing.Point(93, 440);
-            this.cboEpics.Name = "cboEpics";
-            this.cboEpics.Size = new System.Drawing.Size(400, 26);
-            this.cboEpics.Sorted = true;
-            this.cboEpics.TabIndex = 7;
-            // 
-            // lstAvailableTags
-            // 
-            this.lstAvailableTags.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.lstAvailableTags.Font = new System.Drawing.Font("Calibri", 11.25F);
-            this.lstAvailableTags.FormattingEnabled = true;
-            this.lstAvailableTags.IntegralHeight = false;
-            this.lstAvailableTags.ItemHeight = 18;
-            this.lstAvailableTags.Location = new System.Drawing.Point(93, 320);
-            this.lstAvailableTags.Name = "lstAvailableTags";
-            this.lstAvailableTags.Size = new System.Drawing.Size(226, 114);
-            this.lstAvailableTags.Sorted = true;
-            this.lstAvailableTags.TabIndex = 5;
-            this.lstAvailableTags.KeyUp += new System.Windows.Forms.KeyEventHandler(this.LstAvailableTags_KeyUp);
-            this.lstAvailableTags.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.LstAvailableTags_MouseDoubleClick);
-            // 
-            // lstSelectedTags
-            // 
-            this.lstSelectedTags.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.lstSelectedTags.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lstSelectedTags.FormattingEnabled = true;
-            this.lstSelectedTags.IntegralHeight = false;
-            this.lstSelectedTags.ItemHeight = 18;
-            this.lstSelectedTags.Location = new System.Drawing.Point(370, 320);
-            this.lstSelectedTags.Name = "lstSelectedTags";
-            this.lstSelectedTags.Size = new System.Drawing.Size(220, 114);
-            this.lstSelectedTags.Sorted = true;
-            this.lstSelectedTags.TabIndex = 6;
-            this.lstSelectedTags.KeyUp += new System.Windows.Forms.KeyEventHandler(this.LstSelectedTags_KeyUp);
-            this.lstSelectedTags.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.LstSelectedTags_MouseDoubleClick);
             // 
             // chkMakeEpic
             // 
@@ -400,6 +312,112 @@ namespace IssueCreator
             this.cboMilestones.Sorted = true;
             this.cboMilestones.TabIndex = 27;
             // 
+            // txtEstimate
+            // 
+            this.txtEstimate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.txtEstimate.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtEstimate.Location = new System.Drawing.Point(93, 472);
+            this.txtEstimate.Name = "txtEstimate";
+            this.txtEstimate.Size = new System.Drawing.Size(63, 26);
+            this.txtEstimate.TabIndex = 24;
+            // 
+            // cboEpics
+            // 
+            this.cboEpics.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.cboEpics.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.cboEpics.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cboEpics.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cboEpics.FormattingEnabled = true;
+            this.cboEpics.IntegralHeight = false;
+            this.cboEpics.Location = new System.Drawing.Point(93, 440);
+            this.cboEpics.Name = "cboEpics";
+            this.cboEpics.Size = new System.Drawing.Size(400, 26);
+            this.cboEpics.Sorted = true;
+            this.cboEpics.TabIndex = 7;
+            // 
+            // lstAvailableTags
+            // 
+            this.lstAvailableTags.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lstAvailableTags.Font = new System.Drawing.Font("Calibri", 11.25F);
+            this.lstAvailableTags.FormattingEnabled = true;
+            this.lstAvailableTags.IntegralHeight = false;
+            this.lstAvailableTags.ItemHeight = 18;
+            this.lstAvailableTags.Location = new System.Drawing.Point(93, 320);
+            this.lstAvailableTags.Name = "lstAvailableTags";
+            this.lstAvailableTags.Size = new System.Drawing.Size(226, 114);
+            this.lstAvailableTags.Sorted = true;
+            this.lstAvailableTags.TabIndex = 5;
+            this.lstAvailableTags.KeyUp += new System.Windows.Forms.KeyEventHandler(this.LstAvailableTags_KeyUp);
+            this.lstAvailableTags.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.LstAvailableTags_MouseDoubleClick);
+            // 
+            // cboAssignees
+            // 
+            this.cboAssignees.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.cboAssignees.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.cboAssignees.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cboAssignees.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cboAssignees.FormattingEnabled = true;
+            this.cboAssignees.Location = new System.Drawing.Point(93, 76);
+            this.cboAssignees.Name = "cboAssignees";
+            this.cboAssignees.Size = new System.Drawing.Size(497, 26);
+            this.cboAssignees.Sorted = true;
+            this.cboAssignees.TabIndex = 2;
+            // 
+            // lstSelectedTags
+            // 
+            this.lstSelectedTags.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.lstSelectedTags.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lstSelectedTags.FormattingEnabled = true;
+            this.lstSelectedTags.IntegralHeight = false;
+            this.lstSelectedTags.ItemHeight = 18;
+            this.lstSelectedTags.Location = new System.Drawing.Point(370, 320);
+            this.lstSelectedTags.Name = "lstSelectedTags";
+            this.lstSelectedTags.Size = new System.Drawing.Size(220, 114);
+            this.lstSelectedTags.Sorted = true;
+            this.lstSelectedTags.TabIndex = 6;
+            this.lstSelectedTags.KeyUp += new System.Windows.Forms.KeyEventHandler(this.LstSelectedTags_KeyUp);
+            this.lstSelectedTags.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.LstSelectedTags_MouseDoubleClick);
+            // 
+            // txtDescription
+            // 
+            this.txtDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtDescription.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.txtDescription.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtDescription.Location = new System.Drawing.Point(93, 140);
+            this.txtDescription.Multiline = true;
+            this.txtDescription.Name = "txtDescription";
+            this.txtDescription.Size = new System.Drawing.Size(497, 151);
+            this.txtDescription.TabIndex = 4;
+            // 
+            // txtIssueTitle
+            // 
+            this.txtIssueTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtIssueTitle.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtIssueTitle.Location = new System.Drawing.Point(93, 108);
+            this.txtIssueTitle.Name = "txtIssueTitle";
+            this.txtIssueTitle.Size = new System.Drawing.Size(497, 26);
+            this.txtIssueTitle.TabIndex = 3;
+            // 
+            // fileToolStripMenuItem
+            // 
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.exitToolStripMenuItem});
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "File";
+            // 
+            // exitToolStripMenuItem
+            // 
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exitToolStripMenuItem.Text = "E&xit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+            // 
             // frmMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -436,7 +454,6 @@ namespace IssueCreator
             this.MinimumSize = new System.Drawing.Size(621, 538);
             this.Name = "frmMain";
             this.Text = "Issue Creator";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FrmMain_FormClosing);
             this.Load += new System.EventHandler(this.FrmMain_Load);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
@@ -479,6 +496,8 @@ namespace IssueCreator
         private CheckBox chkMakeEpic;
         private Label label9;
         private ComboBoxWithSearch cboMilestones;
+        private ToolStripMenuItem fileToolStripMenuItem;
+        private ToolStripMenuItem exitToolStripMenuItem;
     }
 }
 

--- a/src/IssueCreator/Models/Contributor.cs
+++ b/src/IssueCreator/Models/Contributor.cs
@@ -1,0 +1,34 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IssueCreator.Models
+{
+    public class GitHubContributor
+    {
+        public string Login { get; set; }
+
+        public GitHubContributor(RepositoryContributor contributor)
+        {
+            Login = contributor.Login;
+        }
+
+        public GitHubContributor() //for deserialization
+        {
+
+        }
+
+        internal static List<GitHubContributor> FromContributorsList(IReadOnlyList<RepositoryContributor> repoContributorList)
+        {
+            List<GitHubContributor> contrib = new List<GitHubContributor>();
+            foreach (RepositoryContributor contributor in repoContributorList)
+            {
+                contrib.Add(new GitHubContributor(contributor));
+            }
+            return contrib;
+        }
+    }
+}

--- a/src/IssueCreator/Models/IssueDescription.cs
+++ b/src/IssueCreator/Models/IssueDescription.cs
@@ -1,11 +1,10 @@
-﻿using Octokit;
-
-namespace IssueCreator.Models
+﻿namespace IssueCreator.Models
 {
     public class IssueDescription
     {
-        public Issue Issue { get; set; }
-        public Repository Repo { get; set; }
+        public IssueObject Issue { get; set; }
+        public RepositoryInfo Repo { get; set; }
+
         public override string ToString()
         {
             return $"{Issue.Title} ({Repo.FullName})";

--- a/src/IssueCreator/Models/IssueMilestone.cs
+++ b/src/IssueCreator/Models/IssueMilestone.cs
@@ -1,23 +1,41 @@
-﻿using System;
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace IssueCreator.Models
 {
     public class IssueMilestone
     {
-        public int? Number { get; private set; }
-        public string Title { get; private set; }
-        public DateTimeOffset? DueOn { get; private set; }
+        public int? Number { get; set; }
+        public string Title { get; set; }
+        public DateTimeOffset? DueOn { get; set; }
 
-        public IssueMilestone(Octokit.Milestone m)
+        public IssueMilestone(Milestone m)
         {
             Number = m.Number;
             Title = m.Title;
             DueOn = m.DueOn;
         }
 
+        public IssueMilestone() // for deserialization
+        {
+
+        }
+
         public override string ToString()
         {
             return $"{Title}";
+        }
+
+        internal static List<IssueMilestone> FromMilestoneList(IReadOnlyList<Milestone> milestones)
+        {
+            List<IssueMilestone> result = new List<IssueMilestone>();
+            foreach (Milestone milestone in milestones)
+            {
+                result.Add(new IssueMilestone(milestone));
+            }
+            return result;
         }
     }
 }

--- a/src/IssueCreator/Models/IssueMilestone.cs
+++ b/src/IssueCreator/Models/IssueMilestone.cs
@@ -28,7 +28,7 @@ namespace IssueCreator.Models
             return $"{Title}";
         }
 
-        internal static List<IssueMilestone> FromMilestoneList(IReadOnlyList<Milestone> milestones)
+        internal static IEnumerable<IssueMilestone> FromMilestoneList(IReadOnlyList<Milestone> milestones)
         {
             List<IssueMilestone> result = new List<IssueMilestone>();
             foreach (Milestone milestone in milestones)

--- a/src/IssueCreator/Models/IssueObject.cs
+++ b/src/IssueCreator/Models/IssueObject.cs
@@ -1,0 +1,28 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IssueCreator.Models
+{
+    public class IssueObject
+    {
+        public string Title { get; set; }
+        public string State { get; set; }
+        public int Number { get; set; }
+
+        public IssueObject(Issue issue)
+        {
+            Title = issue.Title;
+            State = issue.State.StringValue;
+            Number = issue.Number;
+        }
+
+        public IssueObject() //for deserialization
+        {
+
+        }
+    }
+}

--- a/src/IssueCreator/Models/RepoLabel.cs
+++ b/src/IssueCreator/Models/RepoLabel.cs
@@ -1,0 +1,34 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IssueCreator.Models
+{
+    public class RepoLabel
+    {
+        public string Name { get; set; }
+
+        public RepoLabel(Label label)
+        {
+            Name = label.Name;
+        }
+
+        public RepoLabel() // for deserialization
+        {
+
+        }
+
+        internal static List<RepoLabel> FromLabelList(IReadOnlyList<Label> labels)
+        {
+            List<RepoLabel> result = new List<RepoLabel>();
+            foreach (Label label in labels)
+            {
+                result.Add(new RepoLabel(label));
+            }
+            return result;
+        }
+    }
+}

--- a/src/IssueCreator/Models/RepositoryInfo.cs
+++ b/src/IssueCreator/Models/RepositoryInfo.cs
@@ -1,0 +1,19 @@
+﻿using Octokit;
+
+namespace IssueCreator.Models
+{
+    public class RepositoryInfo
+    {
+        public long Id { get; set; }
+        public string FullName { get; set; }
+        public RepositoryInfo(Repository repo)
+        {
+            Id = repo.Id;
+            FullName = repo.FullName;
+        }
+        public RepositoryInfo() //for deserialization
+        {
+
+        }
+    }
+}

--- a/src/IssueCreator/Settings.cs
+++ b/src/IssueCreator/Settings.cs
@@ -12,6 +12,7 @@ namespace IssueCreator
         private static readonly byte[] s_entropy = { 23, 61, 24, 8, 77, 52 }; //the entropy
 
         public List<string> Repositories { get; set; } = new List<string>();
+
         public string ZenHubToken { get; set; } = string.Empty;
 
         public string GitHubToken { get; set; } = string.Empty;


### PR DESCRIPTION
This introduces a mechanism where the data retrieved from the site is cached to disk.

The cache is read at application start and the entries are added to the cache with a short time-out. This will force an update of the data 10 minutes after the application starts.

As data comes back from the server, it is cached to disk for future use.

As part of this change, I introduce a few more models to allow the deserializer to work (most of the Octokit types are "read-only").

Fixes #7.

