### PR TITLE
Fix the action that uploads the installer to Azure Blob Storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Build Application
 
 on:
 - pull_request
@@ -24,8 +24,3 @@ jobs:
 
     - name: Build
       run: msbuild ./src/IssueCreator.sln /p:Configuration=Release
-
-    # - name: Deploy
-    #   if: ${{ github.event_name == 'push' }}
-    #   run: >
-    #     echo TODO: Push files to container

--- a/.github/workflows/publishToAzure.yml
+++ b/.github/workflows/publishToAzure.yml
@@ -34,5 +34,5 @@ jobs:
       with:
         connection-string: ${{ secrets.ConnectionString }}
         name: 'installer/..'
-        container: 'testcontainer'
+        container: 'installer'
         path: ./src/IssueCreator/bin/Release/app.publish/

--- a/.github/workflows/publishToAzure.yml
+++ b/.github/workflows/publishToAzure.yml
@@ -33,6 +33,6 @@ jobs:
       uses: fixpoint/azblob-upload-artifact@v4
       with:
         connection-string: ${{ secrets.ConnectionString }}
-        name: app.publish
-        container: testContainer
-        path: ./bin/src/IssueCreator/Debug/app.publish
+        name: 'installer/..'
+        container: 'testcontainer'
+        path: ./src/IssueCreator/bin/Release/app.publish/


### PR DESCRIPTION
This enables the publish of the ClickOnce application to Blob Storage when a new release is created.

To ensure that we continue to publish to the same folder as before I had to 'hack' the existing action and [this](https://github.com/AlexGhiondea/IssueCreator/pull/25/files#diff-78058443ec0d1d61c8f00a5ba1dac75bR36) was needed.

Fixes #14 